### PR TITLE
Switch import to watchlyhq project

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,5 +1,5 @@
 {
-	"ImportPath": "github.com/hpcloud/tail",
+	"ImportPath": "github.com/watchlyhq/tail",
 	"GoVersion": "go1.5.1",
 	"Deps": [
 		{

--- a/cmd/gotail/gotail.go
+++ b/cmd/gotail/gotail.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/hpcloud/tail"
+	"github.com/watchlyhq/tail"
 )
 
 func args2config() (tail.Config, int64) {

--- a/tail.go
+++ b/tail.go
@@ -15,9 +15,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hpcloud/tail/ratelimiter"
-	"github.com/hpcloud/tail/util"
-	"github.com/hpcloud/tail/watch"
+	"github.com/watchlyhq/tail/ratelimiter"
+	"github.com/watchlyhq/tail/util"
+	"github.com/watchlyhq/tail/watch"
 	"gopkg.in/tomb.v1"
 )
 

--- a/tail_test.go
+++ b/tail_test.go
@@ -14,8 +14,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hpcloud/tail/ratelimiter"
-	"github.com/hpcloud/tail/watch"
+	"github.com/watchlyhq/tail/ratelimiter"
+	"github.com/watchlyhq/tail/watch"
 )
 
 func init() {

--- a/tail_windows.go
+++ b/tail_windows.go
@@ -3,8 +3,9 @@
 package tail
 
 import (
-	"github.com/hpcloud/tail/winfile"
 	"os"
+
+	"github.com/watchlyhq/tail/winfile"
 )
 
 func OpenFile(name string) (file *os.File, err error) {

--- a/watch/inotify.go
+++ b/watch/inotify.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/hpcloud/tail/util"
+	"github.com/watchlyhq/tail/util"
 
 	"gopkg.in/fsnotify.v1"
 	"gopkg.in/tomb.v1"

--- a/watch/inotify_tracker.go
+++ b/watch/inotify_tracker.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/hpcloud/tail/util"
+	"github.com/watchlyhq/tail/util"
 
 	"gopkg.in/fsnotify.v1"
 )

--- a/watch/polling.go
+++ b/watch/polling.go
@@ -8,7 +8,7 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/hpcloud/tail/util"
+	"github.com/watchlyhq/tail/util"
 	"gopkg.in/tomb.v1"
 )
 


### PR DESCRIPTION
Replace all `import "github.com/hpcloud/tail"` with this import path.

This fixes duplicate imports (since `gvt` also fetched the hpcloud repo) and makes the Go type checker happy again (since all types come from one import, not two).

![Go type checker be like](https://media.giphy.com/media/daUOBsa1OztxC/giphy.gif)